### PR TITLE
Redirect insecure requests to HTTPS scheme

### DIFF
--- a/runapp.py
+++ b/runapp.py
@@ -31,11 +31,15 @@ from pyramid.paster import setup_logging
 from raven.middleware import Sentry
 from waitress import serve
 
+from yithlibraryserver.compat import urlparse
+
 
 @wsgify.middleware
 def ForceTLSMiddleware(req, app):
     if 'X-Forwarded-Proto' in req.headers and req.headers['X-Forwarded-Proto'] != 'https':
-        https_url = req.url.replace('http://', 'https://')
+        url = list(urlparse.urlparse(req.url))
+        url[0] = 'https'
+        https_url = urlparse.urlunparse(url)
         return HTTPMovedPermanently(location=https_url)
     return req.get_response(app)
 


### PR DESCRIPTION
Platforms like Heroku are already offering a TLS endpoint in
addition to the plain HTTP scheme. But since both schemes work
independently from each other, any redirection must be done in
the application server.

This patch solves that adding a new middleware in order to inspect
for every connection some of the HTTP headers sent from the load
balancer (in the case of Heroku).

Based on this post:
http://brandon-bradley.com/blog/2014/11/heroku-piggyback-ssl-for-pyramid-1-5/