### PR TITLE
  Document how to set up PostgreSQL.

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -41,6 +41,33 @@ To activate the Virtual Python Environment, execute this command:
    $ source bin/activate
    $ cd yith-library-server
 
+Setting up the test database
+----------------------------
+
+:program:`Yith Library Server` needs a `test_yithlibrary` database for
+the tests to run. The PostgreSQL database server should have been
+set up as per :ref:`installation_chapter`. You can then
+create the test database with this commands:
+
+.. code-block:: text
+
+   $ sudo su - postgres
+   $ createdb -E UTF8 -O postgres test_yithlibrary
+
+Then add this line to the top of your PostgreSQL installation
+*pg_hba.conf* file:
+
+.. code-block:: text
+
+   local   test_yithlibrary   postgres   trust
+
+This will allow the `postgres` user to connect to the
+`test_yithlibrary` database without a password as long as the
+connection is local, which should be the case for the tests.
+
+You will need to restart the PostgreSQL server for this configuration
+change to take effect.
+
 Running the tests
 -----------------
 

--- a/yithlibraryserver/config-templates/development.ini
+++ b/yithlibraryserver/config-templates/development.ini
@@ -29,7 +29,7 @@ session.cookie_on_exception = true
 auth_tk_secret = 123456
 
 # Database
-database_url = postgresql://<username>:<password>@localhost:5432/yithlibrary
+database_url = postgresql://yithlibrary:<password>@localhost:5432/yithlibrary
 
 # Webassets
 webassets.debug = True

--- a/yithlibraryserver/config-templates/production.ini
+++ b/yithlibraryserver/config-templates/production.ini
@@ -33,7 +33,7 @@ redis.sessions.cookie_secure = true
 # auth_tk_secret = this_value_must_be_secret
 
 # Database
-# mongo_uri = mongodb://localhost:27017/yith-library
+database_url = postgresql://yithlibrary:<password>@localhost:5432/yithlibrary
 
 # Webassets
 webassets.debug = False

--- a/yithlibraryserver/testing.py
+++ b/yithlibraryserver/testing.py
@@ -83,7 +83,7 @@ def sqlalchemy_teardown(context):
 
 
 def get_test_db_uri():
-    return 'postgresql://postgres@localhost:5432/test_yithlibrary'
+    return 'postgresql://postgres@/test_yithlibrary'
 
 
 class TestCase(unittest.TestCase):


### PR DESCRIPTION
yith-library-server doesn't use MongoDB anymore, it uses PostgreSQL. This PR adds some documentation on how to install a PostgreSQL server and set it up for the application.

@lorenzogil please take a look.